### PR TITLE
Update lambda wrapper to use latest signalfx-java library

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ SIGNALFX_LAMBDA_HANDLER=com.signalfx.lambda.example.CustomHandler::handler
 
 ## License
 
-Apache Software License v2. Copyright © 2014-2020 SignalFx
+Apache Software License v2. Copyright © 2014-2020 Splunk

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SignalFx Java Lambda Wrapper.
 
 ## Supported Languages
 
-* Java 7+
+* Java 8+
 
 ## Usage
 
@@ -15,7 +15,7 @@ The SignalFx Java Lambda Wrapper is a wrapper around an AWS Lambda Java function
 <dependency>
   <groupId>com.signalfx.public</groupId>
   <artifactId>signalfx-lambda</artifactId>
-  <version>0.0.8</version>
+  <version>0.1</version>
 </dependency>
 ```
 
@@ -119,7 +119,8 @@ Test example is available at `com.signalfx.lambda.example.CustomHandler::handler
 ### Testing locally.
 1) Set test input event and lambda function handler:
 ```
-LAMBDA_INPUT_EVENT={"abc": "def"}
+LAMBDA_INPUT_EVENT='{"abc": "def"}'
+LAMBDA_RUNNER_HANDLER=com.signalfx.lambda.wrapper.SignalFxRequestWrapper
 SIGNALFX_LAMBDA_HANDLER=com.signalfx.lambda.example.CustomHandler::handler
 ```
 2) Run `mvn compile exec:java`.
@@ -132,4 +133,4 @@ SIGNALFX_LAMBDA_HANDLER=com.signalfx.lambda.example.CustomHandler::handler
 
 ## License
 
-Apache Software License v2. Copyright © 2014-2017 SignalFx
+Apache Software License v2. Copyright © 2014-2020 SignalFx

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.signalfx.public</groupId>
     <artifactId>signalfx-lambda</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.8</version>
+    <version>0.1</version>
     <name>SignalFx Lambda Wrapper</name>
     <description>
         SignalFx Lambda Wrapper
@@ -14,6 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
 
     <url>http://www.signalfx.com</url>
@@ -149,7 +150,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -159,17 +160,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.signalfx.public</groupId>
             <artifactId>signalfx-java</artifactId>
-            <version>0.0.37</version>
-        </dependency>
-        <dependency>
-            <groupId>com.signalfx.public</groupId>
-            <artifactId>signalfx-protoc</artifactId>
-            <version>0.0.37</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -179,17 +175,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.8</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.8</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.8</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -239,7 +235,9 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/java/com/signalfx/lambda/runner/LambdaRunnerContext.java
+++ b/src/java/com/signalfx/lambda/runner/LambdaRunnerContext.java
@@ -65,6 +65,16 @@ public class LambdaRunnerContext implements Context {
 
     @Override
     public LambdaLogger getLogger() {
-        return System.out::println;
+        return new LambdaLogger() {
+            @Override
+            public void log(String s) {
+                System.out.println(s);
+            }
+
+            @Override
+            public void log(byte[] bytes) {
+                System.out.println(new String(bytes));
+            }
+        };
     }
 }


### PR DESCRIPTION
Update lambda wrapper to use latest signalfx-java library

There were some conflicts before reported by a customer with httpclient in signalfx-java and the aws-sdk. signalfx-java now shades httpclient and this appears to resolve the issue.